### PR TITLE
feat: Better Github pat detection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Suggests:
     httptest2,
     knitr,
     rmarkdown,
+    rsvg,
     svglite,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,35 +1,35 @@
-Package: hexFinder
 Type: Package
+Package: hexFinder
 Title: Find Hex Logos for CRAN Packages
-Version: 0.8.3
-Authors@R: person("Pedro", "Silva", email = "pedrocoutinhosilva@gmail.com",
-  role = c("aut", "cre"))
+Version: 0.8.4
+Authors@R:
+    person("Pedro", "Silva", , "pedrocoutinhosilva@gmail.com", role = c("aut", "cre"))
 Description: Scavenge the web for possible hex logos for CRAN packages.
 License: MIT + file LICENSE
 URL: https://pedrocsilva.com
-Encoding: UTF-8
-LazyData: true
 Depends:
-  R (>= 4.3.0)
+    R (>= 4.3.0)
 Imports:
-  ggplot2,
-  hexSticker,
-  tools,
-  utils,
-  methods,
-  magick,
-  glue,
-  jsonlite,
-  pkgsearch,
-  purrr,
-  stringr,
-  httr2
-RoxygenNote: 7.3.1
+    ggplot2,
+    glue,
+    hexSticker,
+    httr2,
+    jsonlite,
+    magick,
+    methods,
+    pkgsearch,
+    purrr,
+    stringr,
+    tools,
+    utils
 Suggests:
-    httptest2,
-    testthat (>= 3.0.0),
     covr,
+    httptest2,
+    knitr,
     rmarkdown,
     svglite,
-    knitr
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3
+Encoding: UTF-8
+LazyData: true
+RoxygenNote: 7.3.2

--- a/R/gather.R
+++ b/R/gather.R
@@ -222,7 +222,8 @@ keep_good_ratio_images <- function(paths, download_endpoint, branch) {
 #' @param repository The github repository to search in.
 #' @param token A github personal access token.
 #'   variable github_pat. If that variable is not set, you might run into API
-#'   limits when running too many queries.
+#'   limits when running too many queries. Looks at github_pat and GITHUB_PAT environment
+#'   variables if NULL.
 #' @param logo_patterns String of valid name.extension file names for files to
 #'   look for, separated by |. pkg_name can be used as a placeholder for
 #'   the package name.
@@ -239,12 +240,15 @@ keep_good_ratio_images <- function(paths, download_endpoint, branch) {
 #' @return A URL to a image or NULL if no image was found
 search_repo_logo <- function(pkg_name,
                              repository,
-                             token = Sys.getenv("github_pat"),
+                             token = NULL,
                              logo_patterns = getOption("hexFinder.logo_patterns"), # nolint
                              ignore_patterns = getOption("hexFinder.ignore_patterns")) { # nolint
 
+  if (is.null(token)) {
+    token = Sys.getenv("github_pat", Sys.getenv("GITHUB_PAT"))
+  }
   # Warn user about github pat. Trigers once per session
-  if (token == "" && getOption("hexFinder.pat_warning_first_time")) {
+  if (isFALSE(nzchar(token)) && getOption("hexFinder.pat_warning_first_time")) {
     log("No github personal access token provided.") # nocov
     log("Limited search rates for github will apply.") # nocov
     log("Set up github_pat environmental variable if you plan to query multiple repos in a short time") # nolint #nocov

--- a/R/gather.R
+++ b/R/gather.R
@@ -188,7 +188,7 @@ keep_good_ratio_images <- function(paths, download_endpoint, branch) {
   purrr::keep(paths, \(entry) {
     # trim white space
     info <- glue("{download_endpoint}/{branch}/{entry$path}") |>
-      image_read() |>
+      image_reader() |>
       image_trim() |>
       magick::image_info()
 
@@ -219,7 +219,7 @@ keep_good_ratio_images <- function(paths, download_endpoint, branch) {
 #' Searches a given github repo URL for the best hex logo image.
 #'
 #' @param pkg_name The mane of the package we want the logo for.
-#' @param repository The github repository to search in.
+#' @param repo The github repository to search in.
 #' @param token A github personal access token.
 #'   variable github_pat. If that variable is not set, you might run into API
 #'   limits when running too many queries. Looks at github_pat and GITHUB_PAT environment
@@ -239,7 +239,7 @@ keep_good_ratio_images <- function(paths, download_endpoint, branch) {
 #' @keywords gather internal
 #' @return A URL to a image or NULL if no image was found
 search_repo_logo <- function(pkg_name,
-                             repository,
+                             repo,
                              token = NULL,
                              logo_patterns = getOption("hexFinder.logo_patterns"), # nolint
                              ignore_patterns = getOption("hexFinder.ignore_patterns")) { # nolint
@@ -257,12 +257,12 @@ search_repo_logo <- function(pkg_name,
   }
 
   # if no valid repo is given, abort
-  if (length(repository) == 0 || repository == "") {
+  if (length(repo) == 0 || repo == "") {
     return(NULL)
   }
 
   # api endpoint based on given repo
-  endpoint <- repository |>
+  endpoint <- repo |>
     str_replace(
       "github.com",
       "api.github.com/repos"
@@ -282,7 +282,7 @@ search_repo_logo <- function(pkg_name,
     pkg_name
   )
 
-  download_endpoint <- repository |> str_replace(
+  download_endpoint <- repo |> str_replace(
     "github.com",
     "raw.githubusercontent.com"
   )

--- a/R/images.R
+++ b/R/images.R
@@ -55,6 +55,15 @@ generate_hex <- function(name,
   output_path
 }
 
+# Detect svg for better reading (fewer errors!)
+image_reader = function(path, ...) {
+  if (tolower(tools::file_ext(path)) == "svg" && requireNamespace("rsvg")) {
+    magick::image_read_svg(path, ...)
+  } else {
+    magick::image_read(path, ...)
+  }
+
+}
 #' Crops the empty space from a image
 #'
 #' @param path The path of the image to crop.
@@ -64,7 +73,7 @@ generate_hex <- function(name,
 #' @keywords images internal
 #' @return No return, called for side effects.
 crop_image <- function(path) {
-  original <- image_read(path)
+  original <- image_reader(path)
   trimmed <-  original |>
     image_trim()
 

--- a/man/search_repo_logo.Rd
+++ b/man/search_repo_logo.Rd
@@ -7,7 +7,7 @@
 search_repo_logo(
   pkg_name,
   repository,
-  token = Sys.getenv("github_pat"),
+  token = NULL,
   logo_patterns = getOption("hexFinder.logo_patterns"),
   ignore_patterns = getOption("hexFinder.ignore_patterns")
 )
@@ -19,7 +19,8 @@ search_repo_logo(
 
 \item{token}{A github personal access token.
 variable github_pat. If that variable is not set, you might run into API
-limits when running too many queries.}
+limits when running too many queries. Looks at github_pat and GITHUB_PAT environment
+variables if NULL.}
 
 \item{logo_patterns}{String of valid name.extension file names for files to
 look for, separated by |. pkg_name can be used as a placeholder for

--- a/man/search_repo_logo.Rd
+++ b/man/search_repo_logo.Rd
@@ -6,7 +6,7 @@
 \usage{
 search_repo_logo(
   pkg_name,
-  repository,
+  repo,
   token = NULL,
   logo_patterns = getOption("hexFinder.logo_patterns"),
   ignore_patterns = getOption("hexFinder.ignore_patterns")
@@ -15,7 +15,7 @@ search_repo_logo(
 \arguments{
 \item{pkg_name}{The mane of the package we want the logo for.}
 
-\item{repository}{The github repository to search in.}
+\item{repo}{The github repository to search in.}
 
 \item{token}{A github personal access token.
 variable github_pat. If that variable is not set, you might run into API


### PR DESCRIPTION
 * feat: The github pat env variable is usually GITHUB_PAT. This detects both github_pat / GITHUB_PAT.
 * chore: Ran `usethis::use_tidy_description`
 * refactor: Renamed `repository` to `repo` to match other functions. Makes debugging easier
 * feat: Detect svgs and use image_read_svg (this [image](https://raw.githubusercontent.com/patterninstitute/hgnc/main/man/figures/logo.svg) fails otherwise)